### PR TITLE
Bumped highlight.js to v9.2.0 (YAML support yay)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/mixu/markdown-stream-utils",
   "dependencies": {
-    "highlight.js": "~8.8.0",
+    "highlight.js": "~9.2.0",
     "js-yaml": "~3.4.3",
     "marked": "~0.3.5",
     "through2": "~0.6.3",

--- a/test/highlight.test.js
+++ b/test/highlight.test.js
@@ -46,18 +46,18 @@ describe('highlighter test', function() {
       results.sort(function(a, b) { return a.path.localeCompare(b.path); });
       assert.equal(results[0].contents, [
         '<h1 id="test">Test</h1>',
-        '<pre class="hljs"><code><span class="hljs-doctype">&lt;!DOCTYPE html&gt;</span>',
-        '<span class="hljs-tag">&lt;<span class="hljs-title">title</span>&gt;</span>Title<span class="hljs-tag">&lt;/<span class="hljs-title">title</span>&gt;</span></code></pre>'
+        '<pre class="hljs"><code><span class="hljs-meta">&lt;!DOCTYPE html&gt;</span>',
+        '<span class="hljs-tag">&lt;<span class="hljs-name">title</span>&gt;</span>Title<span class="hljs-tag">&lt;/<span class="hljs-name">title</span>&gt;</span></code></pre>'
       ].join('\n'));
 
       assert.equal(results[1].contents, [
         '<h1 id="test">Test</h1>',
-        '<pre class="hljs"><code><span class="hljs-function"><span class="hljs-keyword">function</span> $<span class="hljs-title">initHighlight</span><span class="hljs-params">(<span class="hljs-keyword">block</span>, <span class="hljs-keyword">flags</span>)</span> <span class="hljs-comment">{ }</span></span></code></pre>'
+        '<pre class="hljs"><code><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">$initHighlight</span>(<span class="hljs-params">block, flags</span>) </span>{ }</code></pre>'
       ].join('\n'));
 
       assert.equal(results[2].contents, [
         '<h1 id="test">Test</h1>',
-        '<pre class="hljs"><code><span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Zebra</span>;</span> <span class="hljs-function"><span class="hljs-keyword">def</span> </span>inspect; <span class="hljs-string">"X<span class="hljs-subst">#{<span class="hljs-number">2</span> + <span class="hljs-keyword">self</span>.object_id}</span>"</span> <span class="hljs-keyword">end</span> <span class="hljs-keyword">end</span></code></pre>'
+        '<pre class="hljs"><code><span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Zebra</span></span>; def inspect; <span class="hljs-string">"X#{2 + self.object_id}"</span> end end</code></pre>'
       ].join('\n'));
       done();
     });
@@ -93,8 +93,8 @@ describe('highlighter test', function() {
       ].join('\n'));
       assert.equal(results[1].contents, [
         '<h1 id="test">Test</h1>',
-        '<pre class="hljs"><code><span class="hljs-doctype">&lt;!DOCTYPE html&gt;</span>',
-        '<span class="hljs-tag">&lt;<span class="hljs-title">title</span>&gt;</span>Title<span class="hljs-tag">&lt;/<span class="hljs-title">title</span>&gt;</span></code></pre>'
+        '<pre class="hljs"><code><span class="hljs-meta">&lt;!DOCTYPE html&gt;</span>',
+        '<span class="hljs-tag">&lt;<span class="hljs-name">title</span>&gt;</span>Title<span class="hljs-tag">&lt;/<span class="hljs-name">title</span>&gt;</span></code></pre>'
       ].join('\n'));
 
       done();


### PR DESCRIPTION
I needed YAML support to paste some RAML specs on my documents so I bumped the `highlight.js` version to 9.2.0.

The tests were not passing when I cloned the repo, my tests were showing fewer tags in the generated HTML for the JS samples, much like they showed after I bumped versions.

After I bumped versions I saw different css classes for HTML documents. I updated the tests, I'm not sure it's OK.

I tested this version against my documents, linking my local clone of this repo on the `package.json` of a cloned `markdown-styles`. YAML was there, beautiful, perfect, shining. Everything else remained the same.
